### PR TITLE
fix up include dir install and add uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,18 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 include_directories(${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/include/hipCPU)
 subdirs(tests)
 
-install(DIRECTORY include DESTINATION include/
+install(DIRECTORY include/hipCPU DESTINATION include
         FILES_MATCHING PATTERN "*.hpp")
-install(DIRECTORY include DESTINATION include/
+install(DIRECTORY include/hipCPU DESTINATION include
         FILES_MATCHING PATTERN "*.h")
 
+# Uninstall target
+if(NOT TARGET uninstall)
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/cmake_uninstall.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+        IMMEDIATE @ONLY)
+
+    add_custom_target(uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()

--- a/cmake_modules/cmake_uninstall.cmake.in
+++ b/cmake_modules/cmake_uninstall.cmake.in
@@ -1,0 +1,23 @@
+# Obtained from: https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif(NOT "${rm_retval}" STREQUAL 0)
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+endforeach(file)


### PR DESCRIPTION
Hey @illuhad , just want to preface this PR by saying you have done some great work in the OS GPGPU realm! Looking forward to using/contributing more to your tools.

This PR cleans up the include directory installation. When I would install hipCPU, the includes would be put in `.../include//include/hipCPU/...`, the first change fixes that up to `.../include/hipCPU/...`.

I also added an uninstall target so that a user can easily `(sudo) make uninstall` and clean up a system level installation he/she might have done with `(sudo) make install`