### PR TITLE
Fix data races in hipcpu::detail::sync_queue

### DIFF
--- a/include/hipCPU/hip/detail/queue.hpp
+++ b/include/hipCPU/hip/detail/queue.hpp
@@ -174,10 +174,10 @@ void async_queue::work()
     _is_idle = false;
     operation();
 
-    _is_idle = [this] {
+    {
       std::lock_guard<std::mutex> lock(_mutex);
-      return _enqueued_operations.empty();
-    }();
+      _is_idle = _enqueued_operations.empty();
+    }
  
     _condition_wait.notify_one();
 

--- a/include/hipCPU/hip/detail/queue.hpp
+++ b/include/hipCPU/hip/detail/queue.hpp
@@ -170,9 +170,11 @@ void async_queue::work()
     _is_idle = false;
     operation();
 
-    if(_enqueued_operations.empty())
-      _is_idle = true;
-
+    _is_idle = [this] {
+      std::lock_guard<std::mutex> lock(_mutex);
+      return _enqueued_operations.empty();
+    }();
+ 
     _condition_wait.notify_one();
 
   }

--- a/include/hipCPU/hip/detail/queue.hpp
+++ b/include/hipCPU/hip/detail/queue.hpp
@@ -138,10 +138,14 @@ void async_queue::work()
   // The loop is executed as long as there are enqueued operations,
   // (_is_operation_pending) or we should wait for new operations
   // (_continue).
-  while(_continue || _enqueued_operations.size() > 0)
+  while(true)
   {
     {
       std::unique_lock<std::mutex> lock(_mutex);
+
+      // enclosing loop termination must be checked while holding
+      // a lock on _enqueued_operations (_continue is std::atomic<bool>)
+      if(!_continue && _enqueued_operations.size() <= 0) break;
 
       // Before going to sleep, wake up the other thread in case it is is waiting
       // for the queue to get empty

--- a/include/hipCPU/hip/detail/queue.hpp
+++ b/include/hipCPU/hip/detail/queue.hpp
@@ -78,7 +78,7 @@ private:
 
   std::thread _async_queue;
 
-  bool _continue;
+  std::atomic<bool> _continue;
 
   std::condition_variable _condition_wait;
   mutable std::mutex _mutex;


### PR DESCRIPTION
This PR fixes several data races detected by `TSAN` while using `hipCPU` as a dependency vendored by `hipSYCL`. Each commit addresses a specific data race while all of them boil down to unsynced accesses to both `sync_queue::_continue` and `sync_queue::_enqueued_operations` (for example, full `TSAN` log of the race fixed by 48eeeff is [here](https://gist.github.com/nazavode/728ff2260ed5ebd3e800a5b44cadaa8f)).