### PR TITLE
Implement hipEventElapsedTime

### DIFF
--- a/include/hipCPU/hip/detail/event.hpp
+++ b/include/hipCPU/hip/detail/event.hpp
@@ -29,6 +29,7 @@
 #define HIPCPU_EVENT_HPP
 
 #include <atomic>
+#include <chrono>
 
 namespace hipcpu {
 
@@ -36,26 +37,32 @@ class event
 {
 public:
   event()
-  : _is_recorded{false}
+  : _record_timestamp{0}
   {}
 
   void wait() const noexcept
   {
-    do {} while (!_is_recorded);
+    do {} while (!_record_timestamp);
   }
 
   void mark_as_finished()
   {
-    _is_recorded = true;
+    auto now = std::chrono::steady_clock::now().time_since_epoch();
+    _record_timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
   }
 
   bool is_complete() const
   {
-    return _is_recorded;
+    return _record_timestamp != 0;
+  }
+
+  uint64_t timestamp_ns() const
+  {
+    return _record_timestamp;
   }
 
 private:
-  std::atomic<bool> _is_recorded;
+  std::atomic<uint64_t> _record_timestamp;
 
 };
 

--- a/include/hipCPU/hip/detail/event.hpp
+++ b/include/hipCPU/hip/detail/event.hpp
@@ -47,8 +47,10 @@ public:
 
   void mark_as_finished()
   {
-    auto now = std::chrono::steady_clock::now().time_since_epoch();
-    _record_timestamp = std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
+    auto stamp = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+    // still report completion correctly on a system with broken steady_clock
+    _record_timestamp = std::max<uint64_t>(static_cast<uint64_t>(stamp), 1u);
   }
 
   bool is_complete() const

--- a/include/hipCPU/hip/hip_runtime.h
+++ b/include/hipCPU/hip/hip_runtime.h
@@ -888,7 +888,22 @@ hipError_t hipEventSynchronize(hipEvent_t event)
   return hipErrorUnknown;
 }
 
-hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop);
+inline
+hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop)
+{
+  if(!_hipcpu_runtime.events().is_valid(start) || !_hipcpu_runtime.events().is_valid(stop))
+    return hipErrorInvalidValue;
+
+  hipcpu::event* start_evt = _hipcpu_runtime.events().get(start);
+  hipcpu::event* stop_evt = _hipcpu_runtime.events().get(stop);
+  if(start_evt->is_complete() && stop_evt->is_complete())
+  {
+    *ms = static_cast<float>(stop_evt->timestamp_ns() - start_evt->timestamp_ns()) / 1e6f;
+    return hipSuccess;
+  }
+
+  return hipErrorUnknown;
+}
 
 inline
 hipError_t hipEventDestroy(hipEvent_t event)


### PR DESCRIPTION
Prerequisite for implementing `event::get_profiling_info` in hipSYCL.

See https://github.com/illuhad/hipSYCL/pull/251.