### PR TITLE
Fix some compiler warnings

### DIFF
--- a/include/hipCPU/hip/detail/runtime.hpp
+++ b/include/hipCPU/hip/detail/runtime.hpp
@@ -114,7 +114,7 @@ public:
 
   bool is_valid(int id) const
   {
-    if(id >= _data.size())
+    if(id < 0 || static_cast<unsigned int>(id) >= _data.size())
       return false;
     if(_data[id] == nullptr)
       return false;
@@ -306,7 +306,11 @@ class runtime
     _devices.push_back(std::make_unique<device>());
     // Create default stream
     int stream_id = _streams.store(std::make_unique<stream>());
+#ifndef NDEBUG
     assert(stream_id == 0);
+#else
+    (void) stream_id;
+#endif
   }
 public:
   static runtime& get()

--- a/include/hipCPU/hip/hip_runtime.h
+++ b/include/hipCPU/hip/hip_runtime.h
@@ -783,7 +783,7 @@ hipError_t hipGetDeviceProperties(hipDeviceProp_t* p_prop, int device)
   std::string device_name = "hipCPU OpenMP host device";
   int max_dim = std::numeric_limits<int>::max();
 
-  strncpy(p_prop->name, device_name.c_str(), 256);
+  strncpy(p_prop->name, device_name.c_str(), sizeof(p_prop->name)-1);
   // TODO: Find available memory
   p_prop->totalGlobalMem = std::numeric_limits<size_t>::max();
   p_prop->sharedMemPerBlock = _hipcpu_runtime.dev().get_max_shared_memory();

--- a/include/hipCPU/hip/hip_runtime.h
+++ b/include/hipCPU/hip/hip_runtime.h
@@ -780,10 +780,12 @@ hipError_t hipGetDeviceProperties(hipDeviceProp_t* p_prop, int device)
   if(device != 0)
     return hipErrorInvalidDevice;
 
-  std::string device_name = "hipCPU OpenMP host device";
+  static const char device_name[] = "hipCPU OpenMP host device";
   int max_dim = std::numeric_limits<int>::max();
 
-  strncpy(p_prop->name, device_name.c_str(), sizeof(p_prop->name)-1);
+  static_assert(sizeof device_name <= sizeof p_prop->name);
+  memcpy(p_prop->name, device_name, sizeof device_name);
+
   // TODO: Find available memory
   p_prop->totalGlobalMem = std::numeric_limits<size_t>::max();
   p_prop->sharedMemPerBlock = _hipcpu_runtime.dev().get_max_shared_memory();


### PR DESCRIPTION
This PR resolves a few warnings by Clang 10.

- `object_storage::is_valid(id)` was comparing signed and unsigned integer types
- `runtime::runtime()` had an unused variable when assertions were
disabled with NDEBUG
- `hipGetDeviceProperties` had a strcpy which could cause a missing
null-terminator in the destination buffer